### PR TITLE
[Feat] company api 구현 (#7)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'mysql:mysql-connector-java:8.0.33'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+    implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/NosleepdriveBackendApplication.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/NosleepdriveBackendApplication.java
@@ -2,7 +2,6 @@ package com.nosleepdrive.nosleepdrivebackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 @SpringBootApplication
 public class NosleepdriveBackendApplication {

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/CustomError.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/CustomError.java
@@ -1,0 +1,12 @@
+package com.nosleepdrive.nosleepdrivebackend.common;
+
+import lombok.Getter;
+
+@Getter
+public class CustomError extends RuntimeException {
+    private final int status;
+    public CustomError(int status, String message) {
+        super(message);
+        this.status = status;
+    }
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.nosleepdrive.nosleepdrivebackend.common;
 
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -26,5 +28,19 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(new SimpleResponse(HttpStatus.BAD_REQUEST.value(), Message.ERR_NULL_INPUT.getMessage()));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<SimpleResponse> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new SimpleResponse(HttpStatus.BAD_REQUEST.value(), Message.ERR_SQL_DATA_INTEGRITY_VIOLATION.getMessage()));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<SimpleResponse> handleEntityNotFoundException(EntityNotFoundException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new SimpleResponse(HttpStatus.BAD_REQUEST.value(), Message.ERR_SQL_NOT_FOUND.getMessage()));
     }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/GlobalExceptionHandler.java
@@ -32,6 +32,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<SimpleResponse> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+        String message = ex.getMessage();
+        if (message.contains("UK_")) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(new SimpleResponse( HttpStatus.CONTINUE.value(), Message.ERR_SQL_DEPLICATION.getMessage()));
+        } else if (message.contains("FK_")) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new SimpleResponse(HttpStatus.BAD_REQUEST.value(), Message.ERR_SQL_FK.getMessage()));
+        }
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(new SimpleResponse(HttpStatus.BAD_REQUEST.value(), Message.ERR_SQL_DATA_INTEGRITY_VIOLATION.getMessage()));

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.nosleepdrive.nosleepdrivebackend.common;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(CustomError.class)
+    public ResponseEntity<SimpleResponse> handleCustomException(CustomError ex) {
+        SimpleResponse response = new SimpleResponse(ex.getStatus(), ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getStatus()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<SimpleResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new SimpleResponse(HttpStatus.BAD_REQUEST.value(), Message.ERR_INVALID_INPUT.getMessage()));
+    }
+
+    @ExceptionHandler(NullPointerException.class)
+    public ResponseEntity<SimpleResponse> handleNullPointerException(NullPointerException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new SimpleResponse(HttpStatus.BAD_REQUEST.value(), Message.ERR_NULL_INPUT.getMessage()));
+    }
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Hash.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Hash.java
@@ -1,10 +1,8 @@
 package com.nosleepdrive.nosleepdrivebackend.common;
 
-import lombok.Setter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -14,7 +12,7 @@ public class Hash {
     private static String salt;
 
     public Hash(@Value("${security.password.salt}") String salt) {
-        this.salt = salt;
+        Hash.salt = salt;
     }
 
     public String HashEncode(String input) {
@@ -33,13 +31,13 @@ public class Hash {
             result=sb.toString();
 
         } catch (NoSuchAlgorithmException e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"입력 형식이 올바르지 않습니다.");
+            throw new CustomError(HttpStatus.BAD_REQUEST.value(),"입력 형식이 올바르지 않습니다.");
         }
 
         return result;
     }
 
     public boolean Match(String input, String hash) {
-        return HashEncode(input).equals(HashEncode(input));
+        return HashEncode(input).equals(hash);
     }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Hash.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Hash.java
@@ -1,0 +1,45 @@
+package com.nosleepdrive.nosleepdrivebackend.common;
+
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Component
+public class Hash {
+    private static String salt;
+
+    public Hash(@Value("${security.password.salt}") String salt) {
+        this.salt = salt;
+    }
+
+    public String HashEncode(String input) {
+        String result = "";
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+
+            md.update((input+salt).getBytes());
+            byte[] pwdsalt = md.digest();
+
+            StringBuffer sb = new StringBuffer();
+            for (byte b : pwdsalt) {
+                sb.append(String.format("%02x", b));
+            }
+
+            result=sb.toString();
+
+        } catch (NoSuchAlgorithmException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"입력 형식이 올바르지 않습니다.");
+        }
+
+        return result;
+    }
+
+    public boolean Match(String input, String hash) {
+        return HashEncode(input).equals(HashEncode(input));
+    }
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
@@ -8,11 +8,13 @@ import lombok.Getter;
 public enum Message{
     SIGNUP_SUCCESS("회원 가입이 완료되었습니다."),
     LOGIN_SUCCESS("로그인 성공."),
+    GET_COMPANY_DATA_SUCCESS("회원 정보 조회 성공."),
     ERR_SIGNUP_DUPLICATION_ID("이미 존재하는 ID입니다."),
     ERR_INVALID_INPUT("입력 형식이 올바르지 않습니다."),
     ERR_NULL_INPUT("입력값이 누락되었습니다."),
     ERR_INVALID_ID_OR_PASSWORD("ID 또는 비밀번호가 올바르지 않습니다."),
-    ERR_IN_TOKEN("토큰 관련 메소드 실행 도중 에러가 발생했습니다.");
+    ERR_IN_TOKEN("토큰 관련 메소드 실행 도중 에러가 발생했습니다."),
+    ERR_VERIFY_TOKEN("인증 정보가 유효하지 않습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
@@ -9,12 +9,15 @@ public enum Message{
     SIGNUP_SUCCESS("회원 가입이 완료되었습니다."),
     LOGIN_SUCCESS("로그인 성공."),
     GET_COMPANY_DATA_SUCCESS("회원 정보 조회 성공."),
+    DELETE_COMPANY_SUCCESS("회원 탈퇴가 완료되었습니다."),
     ERR_SIGNUP_DUPLICATION_ID("이미 존재하는 ID입니다."),
     ERR_INVALID_INPUT("입력 형식이 올바르지 않습니다."),
     ERR_NULL_INPUT("입력값이 누락되었습니다."),
     ERR_INVALID_ID_OR_PASSWORD("ID 또는 비밀번호가 올바르지 않습니다."),
     ERR_IN_TOKEN("토큰 관련 메소드 실행 도중 에러가 발생했습니다."),
-    ERR_VERIFY_TOKEN("인증 정보가 유효하지 않습니다.");
+    ERR_VERIFY_TOKEN("인증 정보가 유효하지 않습니다."),
+    ERR_SQL_DATA_INTEGRITY_VIOLATION("데이터 무결성 위반."),
+    ERR_SQL_NOT_FOUND("데이터 찾기 실패.");
 
     private final String message;
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
@@ -7,9 +7,12 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum Message{
     SIGNUP_SUCCESS("회원 가입이 완료되었습니다."),
+    LOGIN_SUCCESS("로그인 성공."),
     ERR_SIGNUP_DUPLICATION_ID("이미 존재하는 ID입니다."),
     ERR_INVALID_INPUT("입력 형식이 올바르지 않습니다."),
-    ERR_NULL_INPUT("입력값이 누락되었습니다.");
+    ERR_NULL_INPUT("입력값이 누락되었습니다."),
+    ERR_INVALID_ID_OR_PASSWORD("ID 또는 비밀번호가 올바르지 않습니다."),
+    ERR_IN_TOKEN("토큰 관련 메소드 실행 도중 에러가 발생했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
@@ -10,6 +10,7 @@ public enum Message{
     LOGIN_SUCCESS("로그인 성공."),
     GET_COMPANY_DATA_SUCCESS("회원 정보 조회 성공."),
     DELETE_COMPANY_SUCCESS("회원 탈퇴가 완료되었습니다."),
+    PATCH_COMPANY_SUCCESS("회원 정보가 수정되었습니다."),
     ERR_SIGNUP_DUPLICATION_ID("이미 존재하는 ID입니다."),
     ERR_INVALID_INPUT("입력 형식이 올바르지 않습니다."),
     ERR_NULL_INPUT("입력값이 누락되었습니다."),
@@ -17,7 +18,9 @@ public enum Message{
     ERR_IN_TOKEN("토큰 관련 메소드 실행 도중 에러가 발생했습니다."),
     ERR_VERIFY_TOKEN("인증 정보가 유효하지 않습니다."),
     ERR_SQL_DATA_INTEGRITY_VIOLATION("데이터 무결성 위반."),
-    ERR_SQL_NOT_FOUND("데이터 찾기 실패.");
+    ERR_SQL_NOT_FOUND("데이터 찾기 실패."),
+    ERR_SQL_DEPLICATION("이미 존재하는 값입니다."),
+    ERR_SQL_FK("존재하지 않는 외래키 참조입니다.");
 
     private final String message;
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
@@ -1,0 +1,15 @@
+package com.nosleepdrive.nosleepdrivebackend.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Message{
+    SIGNUP_SUCCESS("회원 가입이 완료되었습니다."),
+    ERR_SIGNUP_DUPLICATION_ID("이미 존재하는 ID입니다."),
+    ERR_INVALID_INPUT("입력 형식이 올바르지 않습니다."),
+    ERR_NULL_INPUT("입력값이 누락되었습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/SimpleResponse.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/SimpleResponse.java
@@ -1,0 +1,12 @@
+package com.nosleepdrive.nosleepdrivebackend.common;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SimpleResponse {
+    private int status;
+    private String message;
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Token.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Token.java
@@ -1,0 +1,76 @@
+package com.nosleepdrive.nosleepdrivebackend.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Component
+public class Token {
+    private static String SECRET_KEY; // 보안에 주의하세요!
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public Token(@Value("${security.token.key}") String key) {
+        Token.SECRET_KEY = key;
+    }
+
+    public static String generateToken(String uid, long expirationEpochSeconds) {
+        try{
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("uid", uid);
+            payload.put("exp", expirationEpochSeconds);
+
+            String payloadJson = objectMapper.writeValueAsString(payload);
+            String encodedPayload = Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.getBytes());
+
+            String signature = sign(encodedPayload, SECRET_KEY);
+
+            return encodedPayload + "." + signature;
+        }
+            catch (Exception e) {
+            throw new CustomError(BAD_REQUEST.value(), Message.ERR_IN_TOKEN.getMessage());
+        }
+    }
+
+    public static boolean verifyToken(String token) {
+        try{
+            String[] parts = token.split("\\.");
+            if (parts.length != 2) return false;
+
+            String encodedPayload = parts[0];
+            String receivedSignature = parts[1];
+
+            String expectedSignature = sign(encodedPayload, SECRET_KEY);
+            if (!expectedSignature.equals(receivedSignature)) return false;
+
+            String payloadJson = new String(Base64.getUrlDecoder().decode(encodedPayload));
+            Map<String, Object> payload = objectMapper.readValue(payloadJson, Map.class);
+
+            long exp = ((Number) payload.get("exp")).longValue();
+            return System.currentTimeMillis() / 1000 < exp;
+        }
+            catch (Exception e) {
+            throw new CustomError(BAD_REQUEST.value(), Message.ERR_IN_TOKEN.getMessage());
+        }
+    }
+
+    private static String sign(String data, String secret) {
+        try {
+            Mac hmac = Mac.getInstance("HmacSHA256");
+            SecretKeySpec key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
+            hmac.init(key);
+            byte[] hash = hmac.doFinal(data.getBytes());
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+        }
+        catch (Exception e) {
+            throw new CustomError(BAD_REQUEST.value(), Message.ERR_IN_TOKEN.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/controller/CompanyController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/controller/CompanyController.java
@@ -3,10 +3,7 @@ package com.nosleepdrive.nosleepdrivebackend.company.controller;
 import com.nosleepdrive.nosleepdrivebackend.common.CustomError;
 import com.nosleepdrive.nosleepdrivebackend.common.Message;
 import com.nosleepdrive.nosleepdrivebackend.common.SimpleResponse;
-import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanyDataResponseDto;
-import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanyLoginRequestDto;
-import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanyLoginResponseDto;
-import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanySignUpRequestDto;
+import com.nosleepdrive.nosleepdrivebackend.company.dto.*;
 import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
 import com.nosleepdrive.nosleepdrivebackend.company.service.CompanyService;
 import jakarta.validation.Valid;
@@ -87,6 +84,27 @@ public class CompanyController {
         SimpleResponse response = new SimpleResponse(
                 customCode,
                 Message.DELETE_COMPANY_SUCCESS.getMessage()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.valueOf(customCode))
+                .body(response);
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<CompanyDataResponseDto> changeCompanyData(@RequestHeader("Authorization") String authHeader, @Valid @RequestBody CompanyChangeRequestDto request) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage());
+        }
+
+        String token = authHeader.substring(7);
+        Company curCompany =  companyService.authCompany(token);
+        companyService.updateCompany(curCompany, request.getPassword(), request.getCompanyName(), request.getBusinessNumber());
+
+        int customCode = HttpStatus.OK.value();
+        CompanyDataResponseDto response = new CompanyDataResponseDto(customCode,
+                Message.PATCH_COMPANY_SUCCESS.getMessage(),
+                curCompany
         );
 
         return ResponseEntity

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/controller/CompanyController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/controller/CompanyController.java
@@ -1,12 +1,45 @@
 package com.nosleepdrive.nosleepdrivebackend.company.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.nosleepdrive.nosleepdrivebackend.common.SimpleResponse;
+import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanySignUpRequestDto;
+import com.nosleepdrive.nosleepdrivebackend.company.service.CompanyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
-@RestController()
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/company")
 public class CompanyController {
-    @GetMapping("/company")
+    private final CompanyService companyService;
+
+    @GetMapping("/")
     public String hello() {
         return "Hello, NoSleepDrive! it's a company!";
+    }
+
+
+    @PostMapping("/signup")
+    public ResponseEntity<SimpleResponse> signup(@RequestBody CompanySignUpRequestDto request) {
+        try {
+            companyService.signup(request);
+
+            SimpleResponse response = new SimpleResponse(
+                    HttpStatus.CREATED.value(),
+                    "회원 가입이 완료되었습니다."
+            );
+
+            return ResponseEntity.ok(response);
+        }
+        catch (ResponseStatusException ex) {
+            SimpleResponse response = new SimpleResponse(
+                    ex.getStatusCode().value(),
+                    ex.getReason()
+            );
+
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        }
     }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/controller/CompanyController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/controller/CompanyController.java
@@ -1,13 +1,14 @@
 package com.nosleepdrive.nosleepdrivebackend.company.controller;
 
+import com.nosleepdrive.nosleepdrivebackend.common.Message;
 import com.nosleepdrive.nosleepdrivebackend.common.SimpleResponse;
 import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanySignUpRequestDto;
 import com.nosleepdrive.nosleepdrivebackend.company.service.CompanyService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,24 +23,17 @@ public class CompanyController {
 
 
     @PostMapping("/signup")
-    public ResponseEntity<SimpleResponse> signup(@RequestBody CompanySignUpRequestDto request) {
-        try {
-            companyService.signup(request);
+    public ResponseEntity<SimpleResponse> signup(@Valid @RequestBody CompanySignUpRequestDto request) {
+        companyService.signup(request);
 
-            SimpleResponse response = new SimpleResponse(
-                    HttpStatus.CREATED.value(),
-                    "회원 가입이 완료되었습니다."
-            );
+        int customCode = HttpStatus.CREATED.value();
+        SimpleResponse response = new SimpleResponse(
+                customCode,
+                Message.SIGNUP_SUCCESS.getMessage()
+        );
 
-            return ResponseEntity.ok(response);
-        }
-        catch (ResponseStatusException ex) {
-            SimpleResponse response = new SimpleResponse(
-                    ex.getStatusCode().value(),
-                    ex.getReason()
-            );
-
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-        }
+        return ResponseEntity
+                .status(HttpStatus.valueOf(customCode))
+                .body(response);
     }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/controller/CompanyController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/controller/CompanyController.java
@@ -29,7 +29,6 @@ public class CompanyController {
 
         String token = authHeader.substring(7);
         Company curCompany =  companyService.authCompany(token);
-        System.out.println(curCompany.getId());
         int customCode = HttpStatus.OK.value();
         CompanyDataResponseDto response = new CompanyDataResponseDto(customCode,
                 Message.GET_COMPANY_DATA_SUCCESS.getMessage(),
@@ -67,6 +66,27 @@ public class CompanyController {
                 customCode,
                 Message.LOGIN_SUCCESS.getMessage(),
                 token
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.valueOf(customCode))
+                .body(response);
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<SimpleResponse> me(@RequestHeader("Authorization") String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage());
+        }
+
+        String token = authHeader.substring(7);
+        Company curCompany =  companyService.authCompany(token);
+        companyService.deleteCompany(curCompany);
+        int customCode = HttpStatus.OK.value();
+
+        SimpleResponse response = new SimpleResponse(
+                customCode,
+                Message.DELETE_COMPANY_SUCCESS.getMessage()
         );
 
         return ResponseEntity

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/controller/CompanyController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/controller/CompanyController.java
@@ -2,6 +2,8 @@ package com.nosleepdrive.nosleepdrivebackend.company.controller;
 
 import com.nosleepdrive.nosleepdrivebackend.common.Message;
 import com.nosleepdrive.nosleepdrivebackend.common.SimpleResponse;
+import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanyLoginRequestDto;
+import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanyLoginResponseDto;
 import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanySignUpRequestDto;
 import com.nosleepdrive.nosleepdrivebackend.company.service.CompanyService;
 import jakarta.validation.Valid;
@@ -30,6 +32,23 @@ public class CompanyController {
         SimpleResponse response = new SimpleResponse(
                 customCode,
                 Message.SIGNUP_SUCCESS.getMessage()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.valueOf(customCode))
+                .body(response);
+    }
+
+
+    @PostMapping("/login")
+    public ResponseEntity<CompanyLoginResponseDto> login(@Valid @RequestBody CompanyLoginRequestDto request){
+        String token = companyService.login(request);
+
+        int customCode = HttpStatus.OK.value();
+        CompanyLoginResponseDto response = new CompanyLoginResponseDto(
+                customCode,
+                Message.LOGIN_SUCCESS.getMessage(),
+                token
         );
 
         return ResponseEntity

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/controller/CompanyController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/controller/CompanyController.java
@@ -1,10 +1,13 @@
 package com.nosleepdrive.nosleepdrivebackend.company.controller;
 
+import com.nosleepdrive.nosleepdrivebackend.common.CustomError;
 import com.nosleepdrive.nosleepdrivebackend.common.Message;
 import com.nosleepdrive.nosleepdrivebackend.common.SimpleResponse;
+import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanyDataResponseDto;
 import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanyLoginRequestDto;
 import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanyLoginResponseDto;
 import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanySignUpRequestDto;
+import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
 import com.nosleepdrive.nosleepdrivebackend.company.service.CompanyService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,9 +21,24 @@ import org.springframework.web.bind.annotation.*;
 public class CompanyController {
     private final CompanyService companyService;
 
-    @GetMapping("/")
-    public String hello() {
-        return "Hello, NoSleepDrive! it's a company!";
+    @GetMapping("/me")
+    public ResponseEntity<CompanyDataResponseDto> getCompanyData(@RequestHeader("Authorization") String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage());
+        }
+
+        String token = authHeader.substring(7);
+        Company curCompany =  companyService.authCompany(token);
+        System.out.println(curCompany.getId());
+        int customCode = HttpStatus.OK.value();
+        CompanyDataResponseDto response = new CompanyDataResponseDto(customCode,
+                Message.GET_COMPANY_DATA_SUCCESS.getMessage(),
+                curCompany
+                );
+
+        return ResponseEntity
+                .status(HttpStatus.valueOf(customCode))
+                .body(response);
     }
 
 

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanyChangeRequestDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanyChangeRequestDto.java
@@ -1,0 +1,23 @@
+package com.nosleepdrive.nosleepdrivebackend.company.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CompanyChangeRequestDto {
+    @Size(min = 8, max = 20)
+    private String password;
+
+    @Size(max = 50)
+    private String companyName;
+
+    @Pattern(regexp = "^[0-9]{10}$")
+    @Size(min = 10, max = 10)
+    private String businessNumber;
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanyDataDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanyDataDto.java
@@ -1,0 +1,30 @@
+package com.nosleepdrive.nosleepdrivebackend.company.dto;
+
+import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class CompanyDataDto {
+    @NotBlank
+    @Size(min = 8, max = 20)
+    private String id;
+
+    @NotBlank
+    @Size(max = 50)
+    private String companyName;
+
+    @Pattern(regexp = "^[0-9]{10}$")
+    @Size(min = 10, max = 10)
+    private String businessNumber;
+
+    public static CompanyDataDto of(Company company) {
+        CompanyDataDto dto = new CompanyDataDto();
+        dto.id = company.getId();
+        dto.companyName = company.getCompanyName();
+        dto.businessNumber = company.getBusinessNumber();
+        return dto;
+    }
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanyDataResponseDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanyDataResponseDto.java
@@ -1,0 +1,17 @@
+package com.nosleepdrive.nosleepdrivebackend.company.dto;
+
+import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
+import lombok.Getter;
+
+@Getter
+public class CompanyDataResponseDto {
+    private int status;
+    private String message;
+    private CompanyDataDto data;
+
+    public CompanyDataResponseDto(int status, String message, Company company) {
+        this.status = status;
+        this.message = message;
+        this.data = CompanyDataDto.of(company);
+    }
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanyLoginRequestDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanyLoginRequestDto.java
@@ -1,0 +1,20 @@
+package com.nosleepdrive.nosleepdrivebackend.company.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CompanyLoginRequestDto {
+    @NotBlank
+    @Size(min = 8, max = 20)
+    private String id;
+
+    @NotBlank
+    @Size(min = 8, max = 20)
+    private String password;
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanyLoginResponseDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanyLoginResponseDto.java
@@ -1,0 +1,13 @@
+package com.nosleepdrive.nosleepdrivebackend.company.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CompanyLoginResponseDto {
+    private int status;
+    private String message;
+    private String token;
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanySignUpRequestDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanySignUpRequestDto.java
@@ -1,0 +1,13 @@
+package com.nosleepdrive.nosleepdrivebackend.company.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CompanySignUpRequestDto {
+    private String id;
+    private String password;
+    private String companyName;
+    private String businessNumber;
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanySignUpRequestDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/dto/CompanySignUpRequestDto.java
@@ -1,4 +1,5 @@
 package com.nosleepdrive.nosleepdrivebackend.company.dto;
+import jakarta.validation.constraints.*;
 
 import lombok.*;
 
@@ -6,8 +7,19 @@ import lombok.*;
 @Setter
 @NoArgsConstructor
 public class CompanySignUpRequestDto {
+    @NotBlank
+    @Size(min = 8, max = 20)
     private String id;
+
+    @NotBlank
+    @Size(min = 8, max = 20)
     private String password;
+
+    @NotBlank
+    @Size(max = 50)
     private String companyName;
+
+    @Pattern(regexp = "^[0-9]{10}$")
+    @Size(min = 10, max = 10)
     private String businessNumber;
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/repository/CompanyRepository.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/repository/CompanyRepository.java
@@ -4,4 +4,5 @@ import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CompanyRepository  extends JpaRepository<Company, Long> {
+    boolean existsById(String id);
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/repository/CompanyRepository.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/repository/CompanyRepository.java
@@ -3,6 +3,9 @@ package com.nosleepdrive.nosleepdrivebackend.company.repository;
 import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CompanyRepository  extends JpaRepository<Company, Long> {
     boolean existsById(String id);
+    Optional<Company> findById(String id);
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/repository/entity/Company.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/repository/entity/Company.java
@@ -8,6 +8,7 @@ import org.springframework.lang.NonNull;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 public class Company {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/repository/entity/Company.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/repository/entity/Company.java
@@ -1,9 +1,13 @@
 package com.nosleepdrive.nosleepdrivebackend.company.repository.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
 import org.springframework.lang.NonNull;
 
 @Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Company {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -15,7 +19,7 @@ public class Company {
     private String id;
 
     @NonNull
-    @Column(name = "password", length = 50, nullable = false)
+    @Column(name = "password", length = 64, nullable = false)
     private String password;
 
     @NonNull

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/repository/entity/Company.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/repository/entity/Company.java
@@ -9,6 +9,7 @@ import org.springframework.lang.NonNull;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 public class Company {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/service/CompanyService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/service/CompanyService.java
@@ -1,10 +1,13 @@
 package com.nosleepdrive.nosleepdrivebackend.company.service;
 
+import com.nosleepdrive.nosleepdrivebackend.common.CustomError;
 import com.nosleepdrive.nosleepdrivebackend.common.Hash;
+import com.nosleepdrive.nosleepdrivebackend.common.Message;
 import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanySignUpRequestDto;
 import com.nosleepdrive.nosleepdrivebackend.company.repository.CompanyRepository;
 import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,7 +18,7 @@ public class CompanyService {
 
     public void signup(CompanySignUpRequestDto request) {
         if (companyRepository.existsById(request.getId())) {
-            throw new RuntimeException("ID already exists");
+            throw new CustomError(HttpStatus.CONFLICT.value(), Message.ERR_SIGNUP_DUPLICATION_ID.getMessage());
         }
 
         Company company = Company.builder()

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/service/CompanyService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/service/CompanyService.java
@@ -11,6 +11,7 @@ import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -54,5 +55,18 @@ public class CompanyService {
 
     public void deleteCompany(Company company) {
         companyRepository.delete(company);
+    }
+
+    @Transactional()
+    public void updateCompany(Company company, String password, String companyName, String businessNumber) {
+        if(businessNumber != null) {
+            company.setBusinessNumber(businessNumber);
+        }
+        if(companyName != null) {
+            company.setCompanyName(companyName);
+        }
+        if(password != null){
+            company.setPassword(hash.HashEncode(password));
+        }
     }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/service/CompanyService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/service/CompanyService.java
@@ -51,4 +51,8 @@ public class CompanyService {
         return companyRepository.findById(uid)
                 .orElseThrow(()->new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage()));
     }
+
+    public void deleteCompany(Company company) {
+        companyRepository.delete(company);
+    }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/service/CompanyService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/service/CompanyService.java
@@ -44,4 +44,11 @@ public class CompanyService {
         }
         return Token.generateToken(target.getIdCompany().toString(), expireTime);
     }
+
+    public Company authCompany(String token){
+        Long uid = Token.verifyToken(token);
+
+        return companyRepository.findById(uid)
+                .orElseThrow(()->new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage()));
+    }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/service/CompanyService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/company/service/CompanyService.java
@@ -1,4 +1,30 @@
 package com.nosleepdrive.nosleepdrivebackend.company.service;
 
+import com.nosleepdrive.nosleepdrivebackend.common.Hash;
+import com.nosleepdrive.nosleepdrivebackend.company.dto.CompanySignUpRequestDto;
+import com.nosleepdrive.nosleepdrivebackend.company.repository.CompanyRepository;
+import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class CompanyService {
+    private final CompanyRepository companyRepository;
+    private final Hash hash;
+
+    public void signup(CompanySignUpRequestDto request) {
+        if (companyRepository.existsById(request.getId())) {
+            throw new RuntimeException("ID already exists");
+        }
+
+        Company company = Company.builder()
+                .id(request.getId())
+                .password(hash.HashEncode(request.getPassword()))
+                .companyName(request.getCompanyName())
+                .businessNumber(request.getBusinessNumber())
+                .build();
+
+        companyRepository.save(company);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,7 @@ spring.config.import=optional:file:.env[.properties]
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
+security.password.salt=${SALT_VALUE}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 security.password.salt=${SALT_VALUE}
+security.token.key=${TOKEN_KEY}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,4 @@ spring.jpa.properties.hibernate.format_sql=true
 
 server.address=0.0.0.0
 server.port=7053
+server.servlet.context-path=/api


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#7 

## 📝 작업 내용

- company api 구현
  - 회원가입
  - 로그인
  - 회원 정보 확인
  - 회원 정보 수정
  - 회원 탈퇴

- 조건 일부 수정
  - company 데이터 수정 이후, 또 다른 api를 보낼 필요 없도록 응답에 company 데이터를 첨부하도록 수정 했습니다.
    - 수정 전
    ```json
    {
      "status": "",
      "message": ""
    }
    ```
     - 수정 후
    ```json
    {
      "status": "",
      "message": "",
      "data" : {
         "id":"",
         "companyName":"",
         "businessNumber":""
       }
    }
    ```
  - businessNumber는 "-"를 제외한 10자의 숫자로 진행합니다.
  - id와 password는 최소한의 보안을 위해 8자 이상으로 해야합니다.

- 로컬 더미데이터를 활용한 테스트
  - postman을 통해 api 응답을 확인해보는 테스트를 진행했습니다.
  - 해당 테스트의 경우, 아래 링크에 업로드 해두었습니다. 참고 부탁드립니다.
  - https://www.notion.so/api-Test-Local-1ebcd825ecaf806aad1eea31d5b970ca

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
