### PR TITLE
[Feat] sleep api 구현 완료(#12)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,6 +66,7 @@ jobs:
           echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
           echo "SALT_VALUE=${{ secrets.SALT_VALUE }}" >> .env
           echo "TOKEN_KEY=${{ secrets.TOKEN_KEY }}" >> .env
+          echo "VIDEO_PATH=${{ secrets.VIDEO_PATH }}" >> .env
           
 
       - name: Check .env file exists

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/FileFunc.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/FileFunc.java
@@ -1,0 +1,61 @@
+package com.nosleepdrive.nosleepdrivebackend.common;
+
+import lombok.AllArgsConstructor;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+@Component
+public class FileFunc {
+    @AllArgsConstructor
+    public class returnFileData {
+        public InputStreamResource stream;
+        public Long fileSize;
+    }
+
+    public returnFileData makeOneFileToZip(String zipFilePath, File videoFile){
+        try {
+            try (FileOutputStream fos = new FileOutputStream(zipFilePath);
+                 ZipOutputStream zipOut = new ZipOutputStream(fos)) {
+                addFileToZip(videoFile, zipOut);
+            }
+
+            Path zipPath = Paths.get(zipFilePath);
+            if (Files.notExists(zipPath)) {
+                throw new CustomError(HttpStatus.INTERNAL_SERVER_ERROR.value(), "압축 파일 생성 실패.");
+            }
+
+            InputStreamResource resource = new InputStreamResource(Files.newInputStream(zipPath));
+            return new returnFileData(resource, Files.size(zipPath));
+        }
+        catch (Exception e){
+            throw new CustomError(HttpStatus.BAD_REQUEST.value(), Message.ERR_DURING_STREAM.getMessage());
+        }
+    }
+
+    private static void addFileToZip(File file, ZipOutputStream zipOut) {
+        try (FileInputStream fis = new FileInputStream(file)) {
+            ZipEntry zipEntry = new ZipEntry(file.getName());
+            zipOut.putNextEntry(zipEntry);
+
+            byte[] bytes = new byte[1024];
+            int length;
+            while ((length = fis.read(bytes)) >= 0) {
+                zipOut.write(bytes, 0, length);
+            }
+        }
+        catch(Exception e){
+            throw new CustomError(HttpStatus.BAD_REQUEST.value(), Message.ERR_DURING_STREAM.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.nosleepdrive.nosleepdrivebackend.common;
 
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,9 +12,19 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(CustomError.class)
-    public ResponseEntity<SimpleResponse<?>> handleCustomException(CustomError ex) {
-        SimpleResponse<?> response = SimpleResponse.withoutData(ex.getMessage());
-        return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getStatus()));
+    public ResponseEntity<SimpleResponse<?>> handleCustomException(CustomError ex, HttpServletResponse res) {
+        try {
+            if (ex.getMessage().compareTo(String.valueOf(Message.ERR_INVALID_VIDEO)) == 0) {
+                res.reset();
+                res.getOutputStream().close();
+            }
+            SimpleResponse<?> response = SimpleResponse.withoutData(ex.getMessage());
+            return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getStatus()));
+        }
+        catch (Exception e) {
+            SimpleResponse<?> response = SimpleResponse.withoutData(ex.getMessage());
+            return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getStatus()));
+        }
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/GlobalExceptionHandler.java
@@ -14,7 +14,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomError.class)
     public ResponseEntity<SimpleResponse<?>> handleCustomException(CustomError ex, HttpServletResponse res) {
         try {
-            if (ex.getMessage().compareTo(String.valueOf(Message.ERR_INVALID_VIDEO)) == 0) {
+            if (ex.getMessage().compareTo(Message.ERR_INVALID_VIDEO.getMessage()) == 0) {
                 res.reset();
                 res.getOutputStream().close();
             }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
@@ -41,6 +41,7 @@ public enum Message{
 
     SAVE_SLEEP_DATA_SUCCESS("졸음 감지 데이터가 저장되었습니다."),
     GET_TODAY_SLEEP_COUNT_SUCCESS("오늘 졸음 감지 횟수 조회 성공."),
+    GET_RECENT_SLEEP_DATA_SUCCESS("최근 졸음 감지 데이터 조회 성공."),
     ERR_INVALID_VIDEO("비디오 데이터를 다시 받아야 합니다.");
 
     private final String message;

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
@@ -32,11 +32,13 @@ public enum Message{
     RENT_SUCCESS("차량 렌트를 시작했습니다."),
     RETURN_SUCCESS("차량 반납이 완료되었습니다."),
     GET_DRIVERS_LIST_SUCCESS("운전자 목록 조회 성공"),
+    SAVE_SLEEP_DATA_SUCCESS("졸음 감지 데이터가 저장되었습니다."),
     ERR_DEPLICATION_VEHICLE("이미 등록된 차량입니다."),
     ERR_NOT_FOUND_VEHICLE("해당 차량을 찾을 수 없습니다."),
     ERR_FORBIDDEN("해당 요청에 대한 권한이 없습니다."),
     ERR_ALREADY_RENT("이미 렌트 중인 차량입니다."),
-    ERR_NOT_RENT("렌트 중이 아닌 차량입니다.");
+    ERR_NOT_RENT("렌트 중이 아닌 차량입니다."),
+    ERR_INVALID_VIDEO("비디오 데이터를 다시 받아야 합니다.");
 
     private final String message;
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
@@ -43,6 +43,7 @@ public enum Message{
     GET_TODAY_SLEEP_COUNT_SUCCESS("오늘 졸음 감지 횟수 조회 성공."),
     GET_RECENT_SLEEP_DATA_SUCCESS("최근 졸음 감지 데이터 조회 성공."),
     GET_SLEEP_LIST_SUCCESS("졸음 감지 목록 조회 성공."),
+    GET_ONE_SLEEP_DATA_SUCCESS("졸음 감지 상세 조회 성공"),
     ERR_INVALID_VIDEO("비디오 데이터를 다시 받아야 합니다.");
 
     private final String message;

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
@@ -42,6 +42,7 @@ public enum Message{
     SAVE_SLEEP_DATA_SUCCESS("졸음 감지 데이터가 저장되었습니다."),
     GET_TODAY_SLEEP_COUNT_SUCCESS("오늘 졸음 감지 횟수 조회 성공."),
     GET_RECENT_SLEEP_DATA_SUCCESS("최근 졸음 감지 데이터 조회 성공."),
+    GET_SLEEP_LIST_SUCCESS("졸음 감지 목록 조회 성공."),
     ERR_INVALID_VIDEO("비디오 데이터를 다시 받아야 합니다.");
 
     private final String message;

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
@@ -44,7 +44,9 @@ public enum Message{
     GET_RECENT_SLEEP_DATA_SUCCESS("최근 졸음 감지 데이터 조회 성공."),
     GET_SLEEP_LIST_SUCCESS("졸음 감지 목록 조회 성공."),
     GET_ONE_SLEEP_DATA_SUCCESS("졸음 감지 상세 조회 성공"),
-    ERR_INVALID_VIDEO("비디오 데이터를 다시 받아야 합니다.");
+    ERR_INVALID_VIDEO("비디오 데이터를 다시 받아야 합니다."),
+    ERR_INVALID_VIDEO_PATH("해당 경로의 비디오 데이터를 찾을 수 없습니다."),
+    ERR_DURING_STREAM("스트림 생성 중 오류가 발생했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
@@ -32,12 +32,15 @@ public enum Message{
     RENT_SUCCESS("차량 렌트를 시작했습니다."),
     RETURN_SUCCESS("차량 반납이 완료되었습니다."),
     GET_DRIVERS_LIST_SUCCESS("운전자 목록 조회 성공"),
-    SAVE_SLEEP_DATA_SUCCESS("졸음 감지 데이터가 저장되었습니다."),
     ERR_DEPLICATION_VEHICLE("이미 등록된 차량입니다."),
     ERR_NOT_FOUND_VEHICLE("해당 차량을 찾을 수 없습니다."),
     ERR_FORBIDDEN("해당 요청에 대한 권한이 없습니다."),
     ERR_ALREADY_RENT("이미 렌트 중인 차량입니다."),
     ERR_NOT_RENT("렌트 중이 아닌 차량입니다."),
+
+
+    SAVE_SLEEP_DATA_SUCCESS("졸음 감지 데이터가 저장되었습니다."),
+    GET_TODAY_SLEEP_COUNT_SUCCESS("오늘 졸음 감지 횟수 조회 성공."),
     ERR_INVALID_VIDEO("비디오 데이터를 다시 받아야 합니다.");
 
     private final String message;

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/driver/repository/DriverRepository.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/driver/repository/DriverRepository.java
@@ -1,7 +1,17 @@
 package com.nosleepdrive.nosleepdrivebackend.driver.repository;
 
 import com.nosleepdrive.nosleepdrivebackend.driver.repository.entity.Driver;
+import com.nosleepdrive.nosleepdrivebackend.vehicle.repository.entity.Vehicle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Date;
+import java.util.List;
 
 public interface DriverRepository extends JpaRepository<Driver, Long> {
+    @Query("SELECT d FROM Driver d WHERE d.vehicle = :vehicle AND d.startTime < :date AND (d.endTime > :date OR d.endTime IS NULL)")
+    List<Driver> findActiveDrivers(
+            @Param("vehicle") Vehicle vehicle,
+            @Param("date") Date date);
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/driver/service/DriverService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/driver/service/DriverService.java
@@ -1,4 +1,26 @@
 package com.nosleepdrive.nosleepdrivebackend.driver.service;
 
+import com.nosleepdrive.nosleepdrivebackend.common.CustomError;
+import com.nosleepdrive.nosleepdrivebackend.common.Message;
+import com.nosleepdrive.nosleepdrivebackend.driver.repository.DriverRepository;
+import com.nosleepdrive.nosleepdrivebackend.driver.repository.entity.Driver;
+import com.nosleepdrive.nosleepdrivebackend.vehicle.repository.entity.Vehicle;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class DriverService {
+    private final DriverRepository driverRepository;
+    public Driver getDriver(Vehicle vehicle, Date date) {
+        List<Driver> drivers = driverRepository.findActiveDrivers(vehicle, date);
+        if(drivers.isEmpty()) {
+            throw new CustomError(HttpStatus.NOT_FOUND.value(), Message.ERR_SQL_NOT_FOUND.getMessage());
+        }
+        return drivers.getLast();
+    }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
@@ -10,6 +10,7 @@ import com.nosleepdrive.nosleepdrivebackend.driver.repository.entity.Driver;
 import com.nosleepdrive.nosleepdrivebackend.driver.service.DriverService;
 import com.nosleepdrive.nosleepdrivebackend.sleep.dto.SaveVideoRequestDto;
 import com.nosleepdrive.nosleepdrivebackend.sleep.dto.SleepDataDto;
+import com.nosleepdrive.nosleepdrivebackend.sleep.dto.SleepListParamDto;
 import com.nosleepdrive.nosleepdrivebackend.sleep.dto.TodaySleepCountDto;
 import com.nosleepdrive.nosleepdrivebackend.sleep.repository.SleepRepository;
 import com.nosleepdrive.nosleepdrivebackend.sleep.service.SleepService;
@@ -94,6 +95,27 @@ public class SleepController {
                 .map(sleepOne->SleepDataDto.of(sleepOne))
                 .collect(Collectors.toList());
         SimpleResponse<List<SleepDataDto>> response = SimpleResponse.withData(Message.GET_RECENT_SLEEP_DATA_SUCCESS.getMessage(), data);
+        return ResponseEntity
+                .status(HttpStatus.OK.value())
+                .body(response);
+    }
+
+    @GetMapping("")
+    public ResponseEntity<SimpleResponse<List<SleepDataDto>>> getRecentSleepData(@RequestHeader("Authorization") String authHeader, @Valid SleepListParamDto param){
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage());
+        }
+
+        String token = authHeader.substring(7);
+        Company curCompany =  companyService.authCompany(token);
+
+        List<SleepDataDto> data = sleepService.getSleepList(curCompany, param)
+                .stream()
+                .skip(param.getPageIdx() * param.getPageSize())
+                .limit(param.getPageSize())
+                .map(sleepOne->SleepDataDto.of(sleepOne))
+                .collect(Collectors.toList());
+        SimpleResponse<List<SleepDataDto>> response = SimpleResponse.withData(Message.GET_SLEEP_LIST_SUCCESS.getMessage(), data);
         return ResponseEntity
                 .status(HttpStatus.OK.value())
                 .body(response);

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
@@ -21,12 +21,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -65,13 +62,13 @@ public class SleepController {
     }
 
     @GetMapping("/today/count")
-    public ResponseEntity<SimpleResponse<TodaySleepCountDto>> getTodaySleepCount(@RequestHeader("Authorization") String authHeader){
+    public ResponseEntity<SimpleResponse<TodaySleepCountDto>> getTodaySleepCount(@RequestHeader("Authorization") String authHeader) {
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             throw new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage());
         }
 
         String token = authHeader.substring(7);
-        Company curCompany =  companyService.authCompany(token);
+        Company curCompany = companyService.authCompany(token);
         int result = sleepService.getTodaySleepCount(curCompany);
         TodaySleepCountDto body = new TodaySleepCountDto(result);
         SimpleResponse<TodaySleepCountDto> response = SimpleResponse.withData(Message.GET_TODAY_SLEEP_COUNT_SUCCESS.getMessage(), body);
@@ -81,18 +78,18 @@ public class SleepController {
     }
 
     @GetMapping("/recent")
-    public ResponseEntity<SimpleResponse<List<SleepDataDto>>> getRecentSleepData(@RequestHeader("Authorization") String authHeader, @Valid PageParam pageData){
+    public ResponseEntity<SimpleResponse<List<SleepDataDto>>> getRecentSleepData(@RequestHeader("Authorization") String authHeader, @Valid PageParam pageData) {
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             throw new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage());
         }
 
         String token = authHeader.substring(7);
-        Company curCompany =  companyService.authCompany(token);
+        Company curCompany = companyService.authCompany(token);
 
         List<SleepDataDto> data = sleepService.getRecentSleeps(curCompany)
                 .stream()
                 .limit(pageData.getPageSize())
-                .map(sleepOne->SleepDataDto.of(sleepOne))
+                .map(sleepOne -> SleepDataDto.of(sleepOne))
                 .collect(Collectors.toList());
         SimpleResponse<List<SleepDataDto>> response = SimpleResponse.withData(Message.GET_RECENT_SLEEP_DATA_SUCCESS.getMessage(), data);
         return ResponseEntity
@@ -101,21 +98,38 @@ public class SleepController {
     }
 
     @GetMapping("")
-    public ResponseEntity<SimpleResponse<List<SleepDataDto>>> getRecentSleepData(@RequestHeader("Authorization") String authHeader, @Valid SleepListParamDto param){
+    public ResponseEntity<SimpleResponse<List<SleepDataDto>>> getSleepDataList(@RequestHeader("Authorization") String authHeader, @Valid SleepListParamDto param) {
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             throw new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage());
         }
 
         String token = authHeader.substring(7);
-        Company curCompany =  companyService.authCompany(token);
+        Company curCompany = companyService.authCompany(token);
 
         List<SleepDataDto> data = sleepService.getSleepList(curCompany, param)
                 .stream()
                 .skip(param.getPageIdx() * param.getPageSize())
                 .limit(param.getPageSize())
-                .map(sleepOne->SleepDataDto.of(sleepOne))
+                .map(sleepOne -> SleepDataDto.of(sleepOne))
                 .collect(Collectors.toList());
         SimpleResponse<List<SleepDataDto>> response = SimpleResponse.withData(Message.GET_SLEEP_LIST_SUCCESS.getMessage(), data);
+        return ResponseEntity
+                .status(HttpStatus.OK.value())
+                .body(response);
+    }
+
+    @GetMapping("/{sleepId}")
+    public ResponseEntity<SimpleResponse<SleepDataDto>> getSleepData(@RequestHeader("Authorization") String authHeader, @PathVariable String sleepId) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage());
+        }
+
+        String token = authHeader.substring(7);
+        Company curCompany = companyService.authCompany(token);
+        SleepDataDto data = SleepDataDto.of(
+                sleepService.getSleep(curCompany, Long.parseLong(sleepId))
+        );
+        SimpleResponse<SleepDataDto> response = SimpleResponse.withData(Message.GET_ONE_SLEEP_DATA_SUCCESS.getMessage(), data);
         return ResponseEntity
                 .status(HttpStatus.OK.value())
                 .body(response);

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
@@ -3,9 +3,12 @@ package com.nosleepdrive.nosleepdrivebackend.sleep.controller;
 import com.nosleepdrive.nosleepdrivebackend.common.CustomError;
 import com.nosleepdrive.nosleepdrivebackend.common.Message;
 import com.nosleepdrive.nosleepdrivebackend.common.SimpleResponse;
+import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
+import com.nosleepdrive.nosleepdrivebackend.company.service.CompanyService;
 import com.nosleepdrive.nosleepdrivebackend.driver.repository.entity.Driver;
 import com.nosleepdrive.nosleepdrivebackend.driver.service.DriverService;
 import com.nosleepdrive.nosleepdrivebackend.sleep.dto.SaveVideoRequestDto;
+import com.nosleepdrive.nosleepdrivebackend.sleep.dto.TodaySleepCountDto;
 import com.nosleepdrive.nosleepdrivebackend.sleep.repository.SleepRepository;
 import com.nosleepdrive.nosleepdrivebackend.sleep.service.SleepService;
 import com.nosleepdrive.nosleepdrivebackend.vehicle.repository.entity.Vehicle;
@@ -28,7 +31,7 @@ import java.util.Date;
 public class SleepController {
     private final VehicleService vehicleService;
     private final DriverService driverService;
-    private final SleepRepository sleepRepository;
+    private final CompanyService companyService;
     private final SleepService sleepService;
 
     @PostMapping("")
@@ -53,6 +56,22 @@ public class SleepController {
         SimpleResponse<?> response = SimpleResponse.withoutData(Message.SAVE_SLEEP_DATA_SUCCESS.getMessage());
         return ResponseEntity
                 .status(HttpStatus.CREATED.value())
+                .body(response);
+    }
+
+    @GetMapping("/today/count")
+    public ResponseEntity<SimpleResponse<TodaySleepCountDto>> getTodaySleepCount(@RequestHeader("Authorization") String authHeader){
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage());
+        }
+
+        String token = authHeader.substring(7);
+        Company curCompany =  companyService.authCompany(token);
+        int result = sleepService.getTodaySleepCount(curCompany);
+        TodaySleepCountDto body = new TodaySleepCountDto(result);
+        SimpleResponse<TodaySleepCountDto> response = SimpleResponse.withData(Message.GET_TODAY_SLEEP_COUNT_SUCCESS.getMessage(), body);
+        return ResponseEntity
+                .status(HttpStatus.OK.value())
                 .body(response);
     }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
@@ -5,10 +5,7 @@ import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
 import com.nosleepdrive.nosleepdrivebackend.company.service.CompanyService;
 import com.nosleepdrive.nosleepdrivebackend.driver.repository.entity.Driver;
 import com.nosleepdrive.nosleepdrivebackend.driver.service.DriverService;
-import com.nosleepdrive.nosleepdrivebackend.sleep.dto.SaveVideoRequestDto;
-import com.nosleepdrive.nosleepdrivebackend.sleep.dto.SleepDataDto;
-import com.nosleepdrive.nosleepdrivebackend.sleep.dto.SleepListParamDto;
-import com.nosleepdrive.nosleepdrivebackend.sleep.dto.TodaySleepCountDto;
+import com.nosleepdrive.nosleepdrivebackend.sleep.dto.*;
 import com.nosleepdrive.nosleepdrivebackend.sleep.repository.SleepRepository;
 import com.nosleepdrive.nosleepdrivebackend.sleep.service.SleepService;
 import com.nosleepdrive.nosleepdrivebackend.vehicle.repository.entity.Vehicle;
@@ -177,6 +174,26 @@ public class SleepController {
 
         String zipFilePath = "sleepData.zip";
         FileFunc.returnFileData zipData = fileFunc.makeOneFileToZip(zipFilePath, videoFile);
+
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=sleepData.zip")
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .contentLength(zipData.fileSize)
+                .body(zipData.stream);
+    }
+
+    @PostMapping("/videos/download")
+    public ResponseEntity<Resource> downloadVideos(@RequestHeader("Authorization") String authHeader, @RequestBody VideoIdsRequestDto ids){
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage());
+        }
+
+        String token = authHeader.substring(7);
+        Company curCompany = companyService.authCompany(token);
+        List<File> videoFile = sleepService.getSleepVideoFiles(curCompany, ids.getIds());
+        String zipFilePath = "sleepData.zip";
+        FileFunc.returnFileData zipData = fileFunc.makeFilesToZip(zipFilePath, videoFile);
 
 
         return ResponseEntity.ok()

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
@@ -2,12 +2,14 @@ package com.nosleepdrive.nosleepdrivebackend.sleep.controller;
 
 import com.nosleepdrive.nosleepdrivebackend.common.CustomError;
 import com.nosleepdrive.nosleepdrivebackend.common.Message;
+import com.nosleepdrive.nosleepdrivebackend.common.PageParam;
 import com.nosleepdrive.nosleepdrivebackend.common.SimpleResponse;
 import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
 import com.nosleepdrive.nosleepdrivebackend.company.service.CompanyService;
 import com.nosleepdrive.nosleepdrivebackend.driver.repository.entity.Driver;
 import com.nosleepdrive.nosleepdrivebackend.driver.service.DriverService;
 import com.nosleepdrive.nosleepdrivebackend.sleep.dto.SaveVideoRequestDto;
+import com.nosleepdrive.nosleepdrivebackend.sleep.dto.SleepDataDto;
 import com.nosleepdrive.nosleepdrivebackend.sleep.dto.TodaySleepCountDto;
 import com.nosleepdrive.nosleepdrivebackend.sleep.repository.SleepRepository;
 import com.nosleepdrive.nosleepdrivebackend.sleep.service.SleepService;
@@ -24,6 +26,8 @@ import java.io.File;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController()
 @RequiredArgsConstructor
@@ -70,6 +74,26 @@ public class SleepController {
         int result = sleepService.getTodaySleepCount(curCompany);
         TodaySleepCountDto body = new TodaySleepCountDto(result);
         SimpleResponse<TodaySleepCountDto> response = SimpleResponse.withData(Message.GET_TODAY_SLEEP_COUNT_SUCCESS.getMessage(), body);
+        return ResponseEntity
+                .status(HttpStatus.OK.value())
+                .body(response);
+    }
+
+    @GetMapping("/recent")
+    public ResponseEntity<SimpleResponse<List<SleepDataDto>>> getRecentSleepData(@RequestHeader("Authorization") String authHeader, @Valid PageParam pageData){
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage());
+        }
+
+        String token = authHeader.substring(7);
+        Company curCompany =  companyService.authCompany(token);
+
+        List<SleepDataDto> data = sleepService.getRecentSleeps(curCompany)
+                .stream()
+                .limit(pageData.getPageSize())
+                .map(sleepOne->SleepDataDto.of(sleepOne))
+                .collect(Collectors.toList());
+        SimpleResponse<List<SleepDataDto>> response = SimpleResponse.withData(Message.GET_RECENT_SLEEP_DATA_SUCCESS.getMessage(), data);
         return ResponseEntity
                 .status(HttpStatus.OK.value())
                 .body(response);

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/SaveVideoRequestDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/SaveVideoRequestDto.java
@@ -14,7 +14,6 @@ import java.util.Date;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class SaveVideoRequestDto {
     @NonNull
     private String deviceUid;

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/SaveVideoRequestDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/SaveVideoRequestDto.java
@@ -1,0 +1,31 @@
+package com.nosleepdrive.nosleepdrivebackend.sleep.dto;
+
+import com.nosleepdrive.nosleepdrivebackend.driver.repository.entity.Driver;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.lang.NonNull;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SaveVideoRequestDto {
+    @NonNull
+    private String deviceUid;
+
+    @NonNull
+    private String detectedAt;
+
+    private Date detectedAtDate;
+
+    private String checksum;
+
+    @NonNull
+    private MultipartFile videoFile;
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/SleepDataDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/SleepDataDto.java
@@ -1,0 +1,35 @@
+package com.nosleepdrive.nosleepdrivebackend.sleep.dto;
+
+import com.nosleepdrive.nosleepdrivebackend.sleep.repository.entity.Sleep;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SleepDataDto {
+    @NonNull
+    private Long idSleep;
+
+    @NonNull
+    private String vehicleNumber;
+
+    @NonNull
+    private Date detectedTime;
+
+    @NonNull
+    private String driverHash;
+
+    public static SleepDataDto of(Sleep sleep) {
+        SleepDataDto dto = new SleepDataDto();
+        dto.idSleep = sleep.getIdSleep();
+        dto.vehicleNumber = sleep.getDriver().getVehicle().getCarNumber();
+        dto.detectedTime = sleep.getSleepTime();
+        dto.driverHash = sleep.getDriver().getDriverHash();
+        return dto;
+    }
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/SleepListParamDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/SleepListParamDto.java
@@ -1,0 +1,25 @@
+package com.nosleepdrive.nosleepdrivebackend.sleep.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SleepListParamDto {
+    @Min(0)
+    private Integer pageIdx = 0;
+    @Min(1)
+    private Integer pageSize = 5;
+
+    private Date startDate;
+    private Date endDate;
+    private String vehicleNumber;
+    private String driverHash;
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/TodaySleepCountDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/TodaySleepCountDto.java
@@ -1,0 +1,12 @@
+package com.nosleepdrive.nosleepdrivebackend.sleep.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class TodaySleepCountDto {
+    private int sleepDetectedToday;
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/VideoIdsRequestDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/VideoIdsRequestDto.java
@@ -1,0 +1,14 @@
+package com.nosleepdrive.nosleepdrivebackend.sleep.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class VideoIdsRequestDto {
+    private List<Long> ids;
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
@@ -2,6 +2,17 @@ package com.nosleepdrive.nosleepdrivebackend.sleep.repository;
 
 import com.nosleepdrive.nosleepdrivebackend.sleep.repository.entity.Sleep;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Date;
+import java.util.List;
 
 public interface SleepRepository extends JpaRepository<Sleep, Long> {
+    @Query("SELECT count(*) FROM Sleep s " +
+            "JOIN s.driver d " +
+            "JOIN d.vehicle v " +
+            "JOIN v.company c " +
+            "WHERE c.idCompany = :companyId AND FUNCTION('DATE', s.sleepTime) = FUNCTION('DATE', :date)")
+    int getCountSleepsByCompanyIdAndDate(@Param("companyId") Long companyId, @Param("date") Date date);
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
@@ -1,6 +1,7 @@
 package com.nosleepdrive.nosleepdrivebackend.sleep.repository;
 
 import com.nosleepdrive.nosleepdrivebackend.sleep.repository.entity.Sleep;
+import com.nosleepdrive.nosleepdrivebackend.vehicle.repository.entity.Vehicle;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -37,4 +38,6 @@ public interface SleepRepository extends JpaRepository<Sleep, Long> {
             @Param("endDate") Date endDate,
             @Param("vehicleNumber") String vehicleNumber,
             @Param("driverHash") String driverHash);
+
+    Sleep findByIdSleep(Long idSleep);
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
@@ -23,4 +23,18 @@ public interface SleepRepository extends JpaRepository<Sleep, Long> {
             "WHERE c.idCompany = :companyId " +
             "ORDER BY s.sleepTime DESC ")
     List<Sleep> getRecentSleep(@Param("companyId") Long companyId);
+
+    @Query("SELECT s FROM Sleep s " +
+            "WHERE (:companyId = s.driver.vehicle.company.idCompany) " +
+            "AND (:startDate IS NULL OR s.sleepTime >= :startDate) " +
+            "AND (:endDate IS NULL OR s.sleepTime <= :endDate) " +
+            "AND (:vehicleNumber IS NULL OR s.driver.vehicle.carNumber = :vehicleNumber) " +
+            "AND (:driverHash IS NULL OR s.driver.driverHash = :driverHash)"+
+            "ORDER BY s.sleepTime DESC ")
+    List<Sleep> getFilteredSleepData(
+            @Param("companyId") Long companyId,
+            @Param("startDate") Date startDate,
+            @Param("endDate") Date endDate,
+            @Param("vehicleNumber") String vehicleNumber,
+            @Param("driverHash") String driverHash);
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
@@ -38,6 +39,9 @@ public interface SleepRepository extends JpaRepository<Sleep, Long> {
             @Param("endDate") Date endDate,
             @Param("vehicleNumber") String vehicleNumber,
             @Param("driverHash") String driverHash);
+
+    @Query("SELECT s FROM Sleep s WHERE s.idSleep IN (:idSleeps)")
+    List<Sleep> getSleepsByIdSleepIsIn(@Param("idSleeps") Collection<Long> idSleeps);
 
     Sleep findByIdSleep(Long idSleep);
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
@@ -15,4 +15,12 @@ public interface SleepRepository extends JpaRepository<Sleep, Long> {
             "JOIN v.company c " +
             "WHERE c.idCompany = :companyId AND FUNCTION('DATE', s.sleepTime) = FUNCTION('DATE', :date)")
     int getCountSleepsByCompanyIdAndDate(@Param("companyId") Long companyId, @Param("date") Date date);
+
+    @Query("SELECT s FROM Sleep s " +
+            "JOIN s.driver d " +
+            "JOIN d.vehicle v " +
+            "JOIN v.company c " +
+            "WHERE c.idCompany = :companyId " +
+            "ORDER BY s.sleepTime DESC ")
+    List<Sleep> getRecentSleep(@Param("companyId") Long companyId);
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/entity/Sleep.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/entity/Sleep.java
@@ -2,11 +2,19 @@ package com.nosleepdrive.nosleepdrivebackend.sleep.repository.entity;
 
 import com.nosleepdrive.nosleepdrivebackend.driver.repository.entity.Driver;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.lang.NonNull;
 
 import java.util.Date;
 
 @Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
 public class Sleep {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
@@ -6,6 +6,7 @@ import com.nosleepdrive.nosleepdrivebackend.common.SimpleResponse;
 import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
 import com.nosleepdrive.nosleepdrivebackend.driver.repository.entity.Driver;
 import com.nosleepdrive.nosleepdrivebackend.sleep.dto.SaveVideoRequestDto;
+import com.nosleepdrive.nosleepdrivebackend.sleep.dto.SleepListParamDto;
 import com.nosleepdrive.nosleepdrivebackend.sleep.repository.SleepRepository;
 import com.nosleepdrive.nosleepdrivebackend.sleep.repository.entity.Sleep;
 import lombok.RequiredArgsConstructor;
@@ -60,5 +61,14 @@ public class SleepService {
 
     public List<Sleep> getRecentSleeps(Company curCompany){
         return sleepRepository.getRecentSleep(curCompany.getIdCompany());
+    }
+
+    public List<Sleep> getSleepList(Company curCompany, SleepListParamDto data){
+        return sleepRepository.getFilteredSleepData(
+                curCompany.getIdCompany(),
+                data.getStartDate(),
+                data.getEndDate(),
+                data.getVehicleNumber(),
+                data.getDriverHash());
     }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.File;
 import java.util.Date;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -55,5 +56,9 @@ public class SleepService {
 
     public int getTodaySleepCount(Company curCompany){
         return sleepRepository.getCountSleepsByCompanyIdAndDate(curCompany.getIdCompany(), new Date());
+    }
+
+    public List<Sleep> getRecentSleeps(Company curCompany){
+        return sleepRepository.getRecentSleep(curCompany.getIdCompany());
     }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.LinkedList;
 import java.util.List;
 
 @Service
@@ -99,5 +100,25 @@ public class SleepService {
             throw new CustomError(HttpStatus.NOT_FOUND.value(), Message.ERR_INVALID_VIDEO_PATH.getMessage());
         }
         return videoFile;
+    }
+
+    public List<File> getSleepVideoFiles(Company curCompany, List<Long> Ids) {
+        List<File> result = new LinkedList<>();
+        List<Sleep> sleeps = sleepRepository.getSleepsByIdSleepIsIn(Ids);
+        for(Sleep sleep: sleeps){
+            if(sleep==null) {
+                continue;
+            }
+            if(sleep.getDriver().getVehicle().getCompany() != curCompany){
+                continue;
+            }
+            File videoFile = new File(sleep.getSleepVideoPath());
+            if (!videoFile.exists()) {
+                continue;
+            }
+            result.add(videoFile);
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.File;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
@@ -30,13 +31,16 @@ public class SleepService {
 
     @Transactional
     public void saveSleepData(Driver curDriver, SaveVideoRequestDto body){
-        File directory = new File(uploadDir);
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy.MM.dd");
+        String dateValue = "/"+sdf.format(body.getDetectedAtDate())+"/";
+        File directory = new File(uploadDir+dateValue);
         if (!directory.exists()) {
             directory.mkdirs();
         }
 
         try {
-            String totalPath = uploadDir + body.getVideoFile().getOriginalFilename();
+            String totalPath = uploadDir +dateValue+ body.getVideoFile().getOriginalFilename();
+            System.out.println("Path: "+totalPath);
             File destinationFile = new File(totalPath);
             body.getVideoFile().transferTo(destinationFile);
 

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
@@ -1,4 +1,54 @@
 package com.nosleepdrive.nosleepdrivebackend.sleep.service;
 
+import com.nosleepdrive.nosleepdrivebackend.common.CustomError;
+import com.nosleepdrive.nosleepdrivebackend.common.Message;
+import com.nosleepdrive.nosleepdrivebackend.common.SimpleResponse;
+import com.nosleepdrive.nosleepdrivebackend.driver.repository.entity.Driver;
+import com.nosleepdrive.nosleepdrivebackend.sleep.dto.SaveVideoRequestDto;
+import com.nosleepdrive.nosleepdrivebackend.sleep.repository.SleepRepository;
+import com.nosleepdrive.nosleepdrivebackend.sleep.repository.entity.Sleep;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.File;
+
+@Service
+@RequiredArgsConstructor
 public class SleepService {
+
+    private final SleepRepository sleepRepository;
+    @Value("${upload.dir}")
+    private String uploadDir;
+
+    @Transactional
+    public void saveSleepData(Driver curDriver, SaveVideoRequestDto body){
+        File directory = new File(uploadDir);
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
+
+        try {
+            String totalPath = uploadDir + body.getVideoFile().getOriginalFilename();
+            File destinationFile = new File(totalPath);
+            body.getVideoFile().transferTo(destinationFile);
+
+            Sleep sleep = Sleep.builder()
+                    .sleepTime(body.getDetectedAtDate())
+                    .sleepVideoPath(totalPath)
+                    .driver(curDriver)
+                    .build();
+            sleepRepository.save(sleep);
+        }
+        catch (CustomError e) {
+            throw e;
+        }
+        catch (Exception e) {
+            System.out.println(e.getMessage());
+            throw new CustomError(HttpStatus.NOT_FOUND.value(), Message.ERR_INVALID_VIDEO.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
@@ -71,4 +71,15 @@ public class SleepService {
                 data.getVehicleNumber(),
                 data.getDriverHash());
     }
+
+    public Sleep getSleep(Company curCompany, long sleepId) {
+        Sleep sleep = sleepRepository.findByIdSleep(sleepId);
+        if(sleep==null) {
+            throw new CustomError(HttpStatus.NOT_FOUND.value(), Message.ERR_NOT_FOUND_VEHICLE.getMessage());
+        }
+        if(sleep.getDriver().getVehicle().getCompany() != curCompany){
+            throw new CustomError(HttpStatus.FORBIDDEN.value(), Message.ERR_FORBIDDEN.getMessage());
+        }
+        return sleep;
+    }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
@@ -82,4 +82,19 @@ public class SleepService {
         }
         return sleep;
     }
+
+    public File getSleepVideoFile(Company curCompany, long sleepId) {
+        Sleep sleep = sleepRepository.findByIdSleep(sleepId);
+        if(sleep==null) {
+            throw new CustomError(HttpStatus.NOT_FOUND.value(), Message.ERR_NOT_FOUND_VEHICLE.getMessage());
+        }
+        if(sleep.getDriver().getVehicle().getCompany() != curCompany){
+            throw new CustomError(HttpStatus.FORBIDDEN.value(), Message.ERR_FORBIDDEN.getMessage());
+        }
+        File videoFile = new File(sleep.getSleepVideoPath());
+        if (!videoFile.exists()) {
+            throw new CustomError(HttpStatus.NOT_FOUND.value(), Message.ERR_INVALID_VIDEO_PATH.getMessage());
+        }
+        return videoFile;
+    }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
@@ -32,7 +32,7 @@ public class SleepService {
     @Transactional
     public void saveSleepData(Driver curDriver, SaveVideoRequestDto body){
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy.MM.dd");
-        String dateValue = "/"+sdf.format(body.getDetectedAtDate())+"/";
+        String dateValue = sdf.format(body.getDetectedAtDate())+"/";
         File directory = new File(uploadDir+dateValue);
         if (!directory.exists()) {
             directory.mkdirs();
@@ -40,7 +40,6 @@ public class SleepService {
 
         try {
             String totalPath = uploadDir +dateValue+ body.getVideoFile().getOriginalFilename();
-            System.out.println("Path: "+totalPath);
             File destinationFile = new File(totalPath);
             body.getVideoFile().transferTo(destinationFile);
 

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
@@ -3,6 +3,7 @@ package com.nosleepdrive.nosleepdrivebackend.sleep.service;
 import com.nosleepdrive.nosleepdrivebackend.common.CustomError;
 import com.nosleepdrive.nosleepdrivebackend.common.Message;
 import com.nosleepdrive.nosleepdrivebackend.common.SimpleResponse;
+import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
 import com.nosleepdrive.nosleepdrivebackend.driver.repository.entity.Driver;
 import com.nosleepdrive.nosleepdrivebackend.sleep.dto.SaveVideoRequestDto;
 import com.nosleepdrive.nosleepdrivebackend.sleep.repository.SleepRepository;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.File;
+import java.util.Date;
 
 @Service
 @RequiredArgsConstructor
@@ -47,8 +49,11 @@ public class SleepService {
             throw e;
         }
         catch (Exception e) {
-            System.out.println(e.getMessage());
             throw new CustomError(HttpStatus.NOT_FOUND.value(), Message.ERR_INVALID_VIDEO.getMessage());
         }
+    }
+
+    public int getTodaySleepCount(Company curCompany){
+        return sleepRepository.getCountSleepsByCompanyIdAndDate(curCompany.getIdCompany(), new Date());
     }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/vehicle/controller/VehicleController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/vehicle/controller/VehicleController.java
@@ -1,9 +1,6 @@
 package com.nosleepdrive.nosleepdrivebackend.vehicle.controller;
 
-import com.nosleepdrive.nosleepdrivebackend.common.CustomError;
-import com.nosleepdrive.nosleepdrivebackend.common.Message;
-import com.nosleepdrive.nosleepdrivebackend.common.PageParam;
-import com.nosleepdrive.nosleepdrivebackend.common.SimpleResponse;
+import com.nosleepdrive.nosleepdrivebackend.common.*;
 import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
 import com.nosleepdrive.nosleepdrivebackend.company.service.CompanyService;
 import com.nosleepdrive.nosleepdrivebackend.driver.dto.DriverDataDto;
@@ -239,4 +236,8 @@ public class VehicleController {
                 .body(response);
     }
 
+    @GetMapping("/{deviceUid}/test/getToken")
+    public String getToken(@PathVariable String deviceUid) {
+        return Token.generateToken(deviceUid, 60*60*24*30*12*5); // 5년
+    }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/vehicle/service/VehicleService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/vehicle/service/VehicleService.java
@@ -3,6 +3,7 @@ package com.nosleepdrive.nosleepdrivebackend.vehicle.service;
 import com.nosleepdrive.nosleepdrivebackend.common.CustomError;
 import com.nosleepdrive.nosleepdrivebackend.common.Hash;
 import com.nosleepdrive.nosleepdrivebackend.common.Message;
+import com.nosleepdrive.nosleepdrivebackend.common.Token;
 import com.nosleepdrive.nosleepdrivebackend.company.repository.entity.Company;
 import com.nosleepdrive.nosleepdrivebackend.driver.repository.DriverRepository;
 import com.nosleepdrive.nosleepdrivebackend.driver.repository.entity.Driver;
@@ -194,5 +195,13 @@ public class VehicleService {
         }
 
         return vehicle.getDrivers();
+    }
+
+    public Vehicle authVehicle(String token) {
+        String uid = Token.verifyTokenHardware(token);
+
+        Vehicle data = vehicleRepository.findByIdHardware(uid);
+        if(data == null) throw new CustomError(HttpStatus.NOT_FOUND.value(), Message.ERR_NOT_FOUND_VEHICLE.getMessage());
+        return data;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,7 @@ spring.datasource.password=${DB_PASSWORD}
 security.password.salt=${SALT_VALUE}
 security.token.key=${TOKEN_KEY}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+upload.dir=${VIDEO_PATH}
 
 spring.jpa.hibernate.ddl-auto=update
 #spring.jpa.hibernate.ddl-auto=validate
@@ -16,3 +17,7 @@ spring.jpa.properties.hibernate.format_sql=true
 server.address=0.0.0.0
 server.port=7053
 server.servlet.context-path=/api
+
+spring.servlet.multipart.enabled=true
+spring.servlet.multipart.max-file-size=50MB
+spring.servlet.multipart.max-request-size=50MB


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#12

## 📝 작업 내용

- sleep api 구현
  - 오늘 졸음 감지 횟수 조회
  - 최근 졸음 감지 데이터 요청
  - 졸음 목록 데이터 조회
  - 졸음 상세 데이터 조회
  - 졸음 영상 1개 재생
  - 졸음 영상 1개 다운로드
  - 졸음 영상 목록 다운로드
  - 졸음 감지 데이터 저장 [embeded->BE]
- 로컬에서 더미데이터를 사용한 테스트

- 조건 일부 수정
  - 졸음 상세 데이터 조회의 불필요한 영상 path 데이터를 제거하여 보안성을 높였습니다.

- 로컬 더미데이터를 활용한 테스트
  postman을 통해 api 응답을 확인해보는 테스트를 진행했습니다.
  해당 sleep 테스트를 이어서 아래 링크에 업로드 해두었습니다. 참고 부탁드립니다.
  https://www.notion.so/api-Test-Local-1ebcd825ecaf806aad1eea31d5b970ca

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
