### PR TITLE
[Fix] video 저장 오류 수정 및 cron 기능 추가 (#18)

### DIFF
--- a/scripts/deleteOldVideo.sh
+++ b/scripts/deleteOldVideo.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+VIDEO_DIR="/home/noSleepDrive/videos"
+
+find "$VIDEO_DIR" -maxdepth 1 -type d -regextype posix-extended -regex ".*/[0-9]{4}\.[0-9]{2}\.[0-9]{2}" | while read -r dir
+do
+    folder_date=$(basename "$dir")
+
+    formatted_date=$(echo "$folder_date" | sed 's/\./-/g')
+
+    if [[ $(date -d "$formatted_date" +%s) -le $(date -d "30 days ago" +%s) ]]; then
+        echo "Deleting: $dir"
+        rm -rf "$dir"
+    fi
+done

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
@@ -56,6 +56,7 @@ public class SleepController {
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSSSS");
             body.setDetectedAtDate(dateFormat.parse(body.getDetectedAt()));
         } catch (ParseException e) {
+            System.out.println(e.getMessage());
             throw new CustomError(HttpStatus.BAD_REQUEST.value(), Message.ERR_INVALID_INPUT.getMessage());
         }
 

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
@@ -38,10 +38,20 @@ public class SleepService {
         if (!directory.exists()) {
             directory.mkdirs();
         }
-
         try {
-            String totalPath = uploadDir +dateValue+ body.getVideoFile().getOriginalFilename();
+            String originalFilename = body.getVideoFile().getOriginalFilename();
+            String totalPath = uploadDir +dateValue+ originalFilename;
+            String baseName = originalFilename.substring(0, originalFilename.lastIndexOf('.'));
+            String extension = originalFilename.substring(originalFilename.lastIndexOf('.'));
             File destinationFile = new File(totalPath);
+            int count = 1;
+            while (destinationFile.exists()) {
+                String newFileName = baseName + "_" + count + extension;
+                totalPath = uploadDir + dateValue + newFileName;
+                destinationFile = new File(totalPath);
+                count++;
+            }
+
             body.getVideoFile().transferTo(destinationFile);
 
             Sleep sleep = Sleep.builder()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#18 

## 📝 작업 내용
- sleep 데이터 저장 시, 영상 이름이 중복인 경우 처리하기
- 서버 실행 시 start.sh 스크립트 자동 실행 처리하기
- 매일 자정 기준, 한 달이 지난 시점의 영상 데이터 삭제 구현하기

### video 저장 제목 중복 처리

-  문제 상황

영상 저장 과정은 영상 path + 날짜 데이터 + 영상 제목을 통해 path 지정 후 저장합니다.

저장 이후에 db에 해당 sleep 데이터를 업데이트하는 방식입니다.

영상 제목에 특별히 사용되는 데이터가 없기 때문에, embeded 내에서 보내는 영상의 제목이 동일하다고 가정했습니다.

해당 경우 같은 날짜에 같은 제목의 영상 데이터가 올 때 덮어씌워지는 문제가 있었습니다.

-  해결 과정

영상 제목을 포함한 path에 이미 같은 path를 가진 파일이 있는지 존재를 확인합니다.

→ 중복 파일이 존재하지 않을 때까지 count값을 증가시키며 영상 파일의 제목 뒤에 숫자를 덧붙이는 형식을 사용해 중복으로 덮어씌워지는 문제를 해결했습니다.


### 서버 실행 시 서비스 자동 실행
- 필요성
서버가 아직 안정적이지 못하여, 재부팅이 필요한 경우가 잦은 상황입니다.

재부팅 시, 매번 start.sh 스크립트를 손수 실행하는 방식은 번거롭고 효율적이지 못한 방식임을 느꼈습니다.

이에 Systemd 서비스를 활용하여 재부팅 시 자동으로 start.sh 스크립트를 실행 할 수 있도록 하고자 했습니다.

- 구현
 Systemd 서비스 파일을 통해 구현을 완료했습니다.

### 30일이 지난 영상 데이터 자동 삭제 기능 추가

- 필요성
렌터카 업체를 타겟층으로 두는 우리 서비스에서는, 많은 수의 차량을 관리할 수 있어야 합니다.

졸음 영상을 계속 쌓아두는 경우, 현 volume 기준으로 디스크 메모리의 크기가 부족할 수 있기 때문에 한 달을 기준으로 더 오래된 영상은 매일 자정 삭제 처리하는 과정을 추가합니다.

- crontab을 이용하여 구현했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

자세한 과정은 아래 문서에 정리해두었습니다.
https://www.notion.so/1f6cd825ecaf80f1ba09e0bf75bf0056?pvs=4
https://www.notion.so/1f6cd825ecaf8094a150fd7ba459ab05
https://www.notion.so/1f6cd825ecaf80e6812ce9d6d55a345f
