### PR TITLE
[Fix] mysql sleep 데이터 시간 저장 오류 해결 (#29)

### DIFF
--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
@@ -6,7 +6,6 @@ import com.nosleepdrive.nosleepdrivebackend.company.service.CompanyService;
 import com.nosleepdrive.nosleepdrivebackend.driver.repository.entity.Driver;
 import com.nosleepdrive.nosleepdrivebackend.driver.service.DriverService;
 import com.nosleepdrive.nosleepdrivebackend.sleep.dto.*;
-import com.nosleepdrive.nosleepdrivebackend.sleep.repository.SleepRepository;
 import com.nosleepdrive.nosleepdrivebackend.sleep.service.SleepService;
 import com.nosleepdrive.nosleepdrivebackend.vehicle.repository.entity.Vehicle;
 import com.nosleepdrive.nosleepdrivebackend.vehicle.service.VehicleService;
@@ -22,16 +21,12 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
-import java.util.zip.ZipOutputStream;
 
 @RestController()
 @RequiredArgsConstructor
@@ -54,6 +49,7 @@ public class SleepController {
         Vehicle curVehicle = vehicleService.authVehicle(token);
         try {
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSSSS");
+            dateFormat.setTimeZone(TimeZone.getTimeZone("Asia/Seoul"));
             body.setDetectedAtDate(dateFormat.parse(body.getDetectedAt()));
         } catch (ParseException e) {
             System.out.println(e.getMessage());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.application.name=nosleepdrive-backend
 spring.config.import=optional:file:.env[.properties]
+spring.messages.encoding=UTF-8
 
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#29

## 📝 작업 내용

SimpleDateFormat은 JVM의 기본 시간대(default timezone)에 따라 String → Date로 파싱합니다.

로컬 Windows와 리눅스 서버의 기본 시간대(JVM default timezone) 가 다르기 때문에 리눅스 서버에서는 UTC를 사용하여 문제가 생길 수 있습니다.

이를 해결하기 위해 명시적으로 KST 시간을 지정했습니다.

### 스크린샷 (선택)
- JVM 지정을 다른 지역으로 했을 때의 시간 오차 화면
![image](https://github.com/user-attachments/assets/727cabee-3786-4264-b4d8-e963513d7f0f)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?