### PR TITLE
[Fix] sleep 데이터의 detacted time 오류 수정 (#29)

### DIFF
--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/NosleepdriveBackendApplication.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/NosleepdriveBackendApplication.java
@@ -1,11 +1,17 @@
 package com.nosleepdrive.nosleepdrivebackend;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class NosleepdriveBackendApplication {
-
+    @PostConstruct
+    public void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
     public static void main(String[] args) {
         SpringApplication.run(NosleepdriveBackendApplication.class, args);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 spring.application.name=nosleepdrive-backend
 spring.config.import=optional:file:.env[.properties]
 spring.messages.encoding=UTF-8
+spring.jackson.time-zone=Asia/Seoul
 
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#29

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존 방식에선 저장된 sleep 데이터를 가져올 때, UTC 시간으로 data를 전달하여 front 측에서 parsing 할 때 어려움을 주게 되었습니다.
JVM 전역 시간과, 전역 시간대 설정을 통해 date 값을 KST 시간으로 전달할 수 있도록 수정했습니다.


### 스크린샷 (선택)
- 수정 후 데이터 확인
  - db
    ![image](https://github.com/user-attachments/assets/8c6a3f42-058c-4d43-b6fb-cf74b73031fb)
  - postman
    ![image](https://github.com/user-attachments/assets/705d1eb5-5d3a-478d-9ea7-a973d0043367)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 애플리케이션의 기본 시간대가 "Asia/Seoul"로 설정되었습니다.
  - JSON 직렬화 및 역직렬화 시 기본 시간대가 "Asia/Seoul"로 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->