### PR TITLE
[deploy] 운전자/차량 별 졸음 감지 횟수 조회 api 반영

### DIFF
--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/Message.java
@@ -44,6 +44,7 @@ public enum Message{
     GET_RECENT_SLEEP_DATA_SUCCESS("최근 졸음 감지 데이터 조회 성공."),
     GET_SLEEP_LIST_SUCCESS("졸음 감지 목록 조회 성공."),
     GET_ONE_SLEEP_DATA_SUCCESS("졸음 감지 상세 조회 성공"),
+    GET_SLEEP_COUNT_SUCCESS("졸음 감지 횟수 조회 성공."),
     ERR_INVALID_VIDEO("비디오 데이터를 다시 받아야 합니다."),
     ERR_INVALID_VIDEO_PATH("해당 경로의 비디오 데이터를 찾을 수 없습니다."),
     ERR_DURING_STREAM("스트림 생성 중 오류가 발생했습니다.");

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
@@ -200,6 +200,24 @@ public class SleepController {
                 .body(zipData.stream);
     }
 
+
+    @GetMapping("/count/by-driver/{driverHash}")
+    public ResponseEntity<SimpleResponse<CountDto>> getCountByDriver(@RequestHeader("Authorization") String authHeader, @PathVariable String driverHash) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage());
+        }
+
+        String token = authHeader.substring(7);
+        Company curCompany = companyService.authCompany(token);
+        int result = sleepService.getSleepCountByDriver(curCompany, driverHash);
+        CountDto body = new CountDto(result);
+        SimpleResponse<CountDto> response = SimpleResponse.withData(Message.GET_SLEEP_COUNT_SUCCESS.getMessage(), body);
+        return ResponseEntity
+                .status(HttpStatus.OK.value())
+                .body(response);
+
+    }
+
     @GetMapping("/{sleepId}")
     public ResponseEntity<SimpleResponse<SleepDataDto>> getSleepData(@RequestHeader("Authorization") String authHeader, @PathVariable String sleepId) {
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
@@ -216,4 +234,5 @@ public class SleepController {
                 .status(HttpStatus.OK.value())
                 .body(response);
     }
+
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
@@ -218,6 +218,23 @@ public class SleepController {
 
     }
 
+    @GetMapping("/count/by-vehicle/{vehicleNumber}")
+    public ResponseEntity<SimpleResponse<CountDto>> getCountByVehicle(@RequestHeader("Authorization") String authHeader, @PathVariable String vehicleNumber) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomError(HttpStatus.UNAUTHORIZED.value(), Message.ERR_VERIFY_TOKEN.getMessage());
+        }
+
+        String token = authHeader.substring(7);
+        Company curCompany = companyService.authCompany(token);
+        int result = sleepService.getSleepCountByVehicle(curCompany, vehicleNumber);
+        CountDto body = new CountDto(result);
+        SimpleResponse<CountDto> response = SimpleResponse.withData(Message.GET_SLEEP_COUNT_SUCCESS.getMessage(), body);
+        return ResponseEntity
+                .status(HttpStatus.OK.value())
+                .body(response);
+
+    }
+
     @GetMapping("/{sleepId}")
     public ResponseEntity<SimpleResponse<SleepDataDto>> getSleepData(@RequestHeader("Authorization") String authHeader, @PathVariable String sleepId) {
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/CountDto.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/dto/CountDto.java
@@ -1,0 +1,12 @@
+package com.nosleepdrive.nosleepdrivebackend.sleep.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CountDto {
+    private int count;
+}

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
@@ -21,6 +21,13 @@ public interface SleepRepository extends JpaRepository<Sleep, Long> {
             "WHERE c.idCompany = :companyId AND FUNCTION('DATE', s.sleepTime) = FUNCTION('DATE', :date)")
     int getCountSleepsByCompanyIdAndDate(@Param("companyId") Long companyId, @Param("date") Date date);
 
+    @Query("SELECT count(*) FROM Sleep s " +
+            "JOIN s.driver d " +
+            "JOIN d.vehicle v " +
+            "JOIN v.company c " +
+            "WHERE c.idCompany = :companyId AND d.driverHash = :driverHash")
+    int getCountSleepsByCompanyIdAndDriverId(@Param("companyId") Long companyId, @Param("driverHash") String driverHash);
+
     @Query("SELECT s FROM Sleep s " +
             "JOIN s.driver d " +
             "JOIN d.vehicle v " +

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/repository/SleepRepository.java
@@ -26,7 +26,14 @@ public interface SleepRepository extends JpaRepository<Sleep, Long> {
             "JOIN d.vehicle v " +
             "JOIN v.company c " +
             "WHERE c.idCompany = :companyId AND d.driverHash = :driverHash")
-    int getCountSleepsByCompanyIdAndDriverId(@Param("companyId") Long companyId, @Param("driverHash") String driverHash);
+    int getCountSleepsByCompanyIdAndDriverHash(@Param("companyId") Long companyId, @Param("driverHash") String driverHash);
+
+    @Query("SELECT count(*) FROM Sleep s " +
+            "JOIN s.driver d " +
+            "JOIN d.vehicle v " +
+            "JOIN v.company c " +
+            "WHERE c.idCompany = :companyId AND v.carNumber = :vehicleNumber")
+    int getCountSleepsByCompanyIdAndVehicleNumber(@Param("companyId") Long companyId, @Param("vehicleNumber") String vehicleNumber);
 
     @Query("SELECT s FROM Sleep s " +
             "JOIN s.driver d " +

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
@@ -133,6 +133,10 @@ public class SleepService {
     }
 
     public int getSleepCountByDriver(Company curCompany, String driverHash){
-        return sleepRepository.getCountSleepsByCompanyIdAndDriverId(curCompany.getIdCompany(), driverHash);
+        return sleepRepository.getCountSleepsByCompanyIdAndDriverHash(curCompany.getIdCompany(), driverHash);
+    }
+
+    public int getSleepCountByVehicle(Company curCompany, String vehicleNumber){
+        return sleepRepository.getCountSleepsByCompanyIdAndVehicleNumber(curCompany.getIdCompany(), vehicleNumber);
     }
 }

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
@@ -131,4 +131,8 @@ public class SleepService {
 
         return result;
     }
+
+    public int getSleepCountByDriver(Company curCompany, String driverHash){
+        return sleepRepository.getCountSleepsByCompanyIdAndDriverId(curCompany.getIdCompany(), driverHash);
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#13 
resolved #36 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

차량 별, 운전자 별 졸음 감지 횟수를 조회할 수 있는 api를 추가하여 이후 웹 페이지 내부에서 사용자(렌탈카 관리자)가 해당 데이터에 손쉽게 접근할 수 있도록 제공합니다.
- 차량 별 데이터 조회 기준 : 차량 번호
- 운전자 별 데이터 조회 기준 : 운전자 해쉬 값

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 운전자 해시 또는 차량 번호로 졸음 감지 횟수를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
- **버그 수정**
    - 해당 없음.
- **기타**
    - 졸음 감지 횟수 정보를 반환하는 응답 메시지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->