### PR TITLE
[Feat] BE 졸음 영상 수신 시 fastStart 영상 변환 처리 추가 (#39)

### DIFF
--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/FileFunc.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/common/FileFunc.java
@@ -66,27 +66,22 @@ public class FileFunc {
                     String type = new String(typeBytes, "UTF-8");
 
                     if ("moov".equals(type)) {
-                        // moov 박스 발견
-                        System.out.println("moov");
-                        return true; // moov가 먼저 나왔으므로 faststart
+                        return true;
                     } else if ("mdat".equals(type)) {
-                        // mdat 박스가 먼저 나오면 faststart 아님
-                        System.out.println("mdat");
                         return false;
                     }
 
-                    if (size < 8) break; // 이상한 박스 크기
-                    raf.seek(pos + size); // 다음 박스 위치로 이동
+                    if (size < 8) break;
+                    raf.seek(pos + size);
                 }
             }
-            return false; // moov 또는 mdat 찾지 못함
+            return false;
         }
         catch (Exception e){
             throw new CustomError(HttpStatus.BAD_REQUEST.value(), Message.ERR_INVALID_VIDEO.getMessage());
         }
     }
     public static void applyFaststart(String inputPath, String outputPath) {
-        System.out.println("this is not preapplied.");
         try {
             ProcessBuilder builder = new ProcessBuilder(
                     "ffmpeg", "-y",

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/controller/SleepController.java
@@ -52,7 +52,6 @@ public class SleepController {
             dateFormat.setTimeZone(TimeZone.getTimeZone("Asia/Seoul"));
             body.setDetectedAtDate(dateFormat.parse(body.getDetectedAt()));
         } catch (ParseException e) {
-            System.out.println(e.getMessage());
             throw new CustomError(HttpStatus.BAD_REQUEST.value(), Message.ERR_INVALID_INPUT.getMessage());
         }
 

--- a/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
+++ b/src/main/java/com/nosleepdrive/nosleepdrivebackend/sleep/service/SleepService.java
@@ -78,11 +78,9 @@ public class SleepService {
             sleepRepository.save(sleep);
         }
         catch (CustomError e) {
-            System.out.println(e.getMessage());
             throw e;
         }
         catch (Exception e) {
-            System.out.println(e.getMessage());
             throw new CustomError(HttpStatus.NOT_FOUND.value(), Message.ERR_INVALID_VIDEO.getMessage());
         }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#39 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

임베디드 클라이언트에서 fastStart로 sleep 영상 변환을 하기엔 성능이 부족하여 전체적인 시스템 지연이 발생한다는 이슈를 전달받았습니다. stream 기능을 제공하기 위해 fastStart 변환 처리는 필수적인 부분이기 때문에, 해당 처리가 되지 않은 영상을 수신한 경우를 판단하여 fastStart를 적용하는 로직을 추가했습니다.
해당 처리는 ffmpeg 모듈을 사용한 방식입니다.

자세한 방식은 아래 문서에 정리했습니다.

https://www.notion.so/BE-fastStart-20ccd825ecaf80da8964e4d25fa45af0

### 스크린샷 (선택)

- 로컬테스트(fastStart 변환이 되지 않은 채 수신한 영상)
![postman_test_notPreprocessedMoovAtom](https://github.com/user-attachments/assets/50b95f5e-9b1b-44ac-8d94-ed3115004c30)
- 로컬테스트(fastStart 변환이 적용된 채 수신한 영상)
![postman_test_preprocessedMoovAtom](https://github.com/user-attachments/assets/2612b555-dddd-49c9-b449-9f4422c7649e)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?