### PR TITLE
deploy[#13]: add KT_C_server connections in cicd

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -77,12 +77,21 @@ jobs:
             echo ".env file does not exist"
           fi
 
+#      - name: Clear old JAR on EC2
+#        uses: appleboy/ssh-action@v0.1.6
+#        with:
+#          host: ${{ secrets.SSH_HOST }}
+#          username: ${{ secrets.SSH_USER }}
+#          key: ${{ secrets.SSH_KEY }}
+#          script: |
+#            echo "Deleting old JAR files..."
+#            rm -f /home/noSleepDrive/app/backend/*.jar
       - name: Clear old JAR on EC2
         uses: appleboy/ssh-action@v0.1.6
         with:
-          host: ${{ secrets.SSH_HOST }}
+          host: ${{ secrets.KT_C_SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
+          key: ${{ secrets.KT_C_SSH_KEY }}
           script: |
             echo "Deleting old JAR files..."
             rm -f /home/noSleepDrive/app/backend/*.jar
@@ -90,9 +99,12 @@ jobs:
       - name: Deploy via SSH
         uses: appleboy/scp-action@v0.1.4
         with:
-          host: ${{ secrets.SSH_HOST }}
+#          host: ${{ secrets.SSH_HOST }}
+#          username: ${{ secrets.SSH_USER }}
+#          key: ${{ secrets.SSH_KEY }}
+          host: ${{ secrets.KT_C_SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
+          key: ${{ secrets.KT_C_SSH_KEY }}
           source: "build/libs/*.jar"
           target: "/home/noSleepDrive/app/backend"
           strip_components: 2
@@ -100,18 +112,24 @@ jobs:
       - name: Deploy .env via SSH
         uses: appleboy/scp-action@v0.1.4
         with:
-          host: ${{ secrets.SSH_HOST }}
+#          host: ${{ secrets.SSH_HOST }}
+#          username: ${{ secrets.SSH_USER }}
+#          key: ${{ secrets.SSH_KEY }}
+          host: ${{ secrets.KT_C_SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
+          key: ${{ secrets.KT_C_SSH_KEY }}
           source: ".env"
           target: "/home/noSleepDrive/app/backend"
           
       - name: Deploy shall script via SSH
         uses: appleboy/scp-action@v0.1.4
         with:
-          host: ${{ secrets.SSH_HOST }}
+#          host: ${{ secrets.SSH_HOST }}
+#          username: ${{ secrets.SSH_USER }}
+#          key: ${{ secrets.SSH_KEY }}
+          host: ${{ secrets.KT_C_SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
+          key: ${{ secrets.KT_C_SSH_KEY }}
           source: "scripts/start.sh"
           target: "/home/noSleepDrive/app/backend"
           strip_components: 1
@@ -119,9 +137,12 @@ jobs:
       - name: Execute start.sh on EC2
         uses: appleboy/ssh-action@v0.1.6
         with:
-          host: ${{ secrets.SSH_HOST }}
+#          host: ${{ secrets.SSH_HOST }}
+#          username: ${{ secrets.SSH_USER }}
+#          key: ${{ secrets.SSH_KEY }}
+          host: ${{ secrets.KT_C_SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
+          key: ${{ secrets.KT_C_SSH_KEY }}
           script: |
             chmod +x /home/noSleepDrive/app/backend/start.sh
             /home/noSleepDrive/app/backend/start.sh


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#13

## 📝 작업 내용

공모전을 통해 지원받은 KT_cloud 서버로 해당 자동 배포가 이루어지도록 수정했습니다.
공모전은 제9회 개방형 클라우드 플랫폼(K-PaaS) 활용 공모전 입니다.

https://www.wevity.com/index.php?c=find&s=_university&gbn=viewok&gp=28&ix=96736

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * GitHub Actions 워크플로우에서 배포 시 사용되는 SSH 연결 시크릿이 `KT_C_SSH_HOST` 및 `KT_C_SSH_KEY`로 변경되었습니다.  
  * 기존 시크릿(`SSH_HOST`, `SSH_KEY`)을 사용하는 단계는 주석 처리되어 비활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->